### PR TITLE
DOC: add task information for NSP

### DIFF
--- a/docs/source/tasks/gap_overlap.rst
+++ b/docs/source/tasks/gap_overlap.rst
@@ -4,11 +4,13 @@ Gap Overlap (GO)
 .. _GO-image:
 
 .. figure:: https://raw.githubusercontent.com/scott-huberty/Q1K-doc-assets/main/_images/task_images/Q1K-Gap-Overlap.png
-    :alt: Gap Overlap
+    :alt: Image of the Gap Overlap task, showing the stimuli and interest areas
     :align: center
 
     Gap-Overlap stimuli and interest area placement and sizing.
 
+Overview
+--------
 
 The Gap Overlap task measures reaction times from a central stimulus to a peripheral
 stimulus. A central stimulus is first presented (spinning clock), followed by a
@@ -21,6 +23,7 @@ for all trials.
 
 .. vimeo:: 874134383
     :align: center
+    :width: 75%
 
 Conditions
 ----------
@@ -78,18 +81,31 @@ Eyelink Host PC (``"Gap"``, ``"Overlap"``, and ``"Baseline"``).
 
 Animations
 ----------
-Central Stimulus
+Central Stimulus (CS)
     At the onset of a trial the Central Stimulus is ``0*0px`` and over ``300ms``
     increases in size to ``350*350px`` (looming). Following this the Central
     Stimulus pulses, increasing/decreasing between ``234*234px`` to ``350*350px`` at
     3Hz (throbbing). Once gaze is detected, the Central Stimulus sized ``234*234px``
     spins clockwise at 1.5Hz.
-Peripheral Stimulus
+Peripheral Stimulus (PS)
     Following the onset of the Peripheral Stimulus, gaze to it triggers a rotation
     animation. The Peripheral stimulus sized at ``234*234px`` rotates clockwise at
     1.5Hz. Finally,
-Reward Stimulus
+Reward Stimulus (RS)
     the reward animation starts at ``234*234px``, reduces to ``0px`` as it rotates
     clockwise at 1.5Hz over 1 second (the reward duration).
 
 
+Event Messaging
+---------------
+
+Throughout the recording sequence of the trial, messages are sent to the Eyelink Host
+PC to mark key onsets, and are written to the Eyelink EDF file. The trial begins
+with a message ``"CS_ONSET"`` when the CS begins to loom. When gaze is
+detected to the CS a message ``"GAZE_TO_CS"`` is written, directly followed by
+``"CS_SPIN"`` when the CS beings spinning for the ``600ms`` (+ jitter value). This is
+followed by ``"ONSET_200MS"`` to signify the ``200ms`` period when the CS either
+remained or left the screen, and then ``"ONSET_PS"`` when the PS is displayed. If gaze
+is oriented to the wrong side, a message ``"GAZE_TO_WRONG_SIDE"`` is written, if gaze is
+to the PS, then ``"GAZE_TO_PS"`` is written, followed by ``"REWARD_ONSET"`` when the
+reward begins. The trial ends with a ``"DISPLAY_BLANK"`` message.

--- a/docs/source/tasks/index.rst
+++ b/docs/source/tasks/index.rst
@@ -12,10 +12,14 @@ battery.
    :hidden:
 
    gap_overlap
+   natural_social_preference
 
 - :doc:`gap_overlap`
+- :doc:`natural_social_preference`
 
-
+The table below denotes the order that the EEG-eyetracking tasks are run in the Q1k,
+and the estimated duration of each task (not including setup, eyetracking calibration,
+and EEG impedance time).
 
 .. table:: Task Order and Durations
     :widths: auto

--- a/docs/source/tasks/natural_social_preference.rst
+++ b/docs/source/tasks/natural_social_preference.rst
@@ -1,0 +1,60 @@
+Naturalistic Social Preference (NSP)
+====================================
+
+.. _NSP-image:
+
+.. figure:: https://raw.githubusercontent.com/scott-huberty/Q1K-doc-assets/main/_images/task_images/Q1K-NSP.png
+    :alt: Image from the NSP task, showing a pixelated video of the 3 actors.
+    :align: center
+
+    NSP scrambled condition and interest area placement and sizing.
+
+Overview
+--------
+
+the NSP task is a freeviewing task, in which participants can freely view a series of
+videos. The videos are matched pairs, termed the Naturalistic and Scrambled conditions.
+The Naturalistic videos show 3 women jumping and moving with objects in their hands
+(i.e. balloons). The scrambled videos are copies of the Naturalistic videos, but are
+pixelated (like that shown in :numref:`NSP-image`). The videos vary in duration across the pairs
+from 21 to 26 seconds. Each video begins with the presentation of the calibration
+animation, centrally presented and the trial proceeds when gaze is held within the 200px
+diameter interest area surrounding the animation for ``50ms``. The video order is
+randomized. There are ten video stimuli in total (5 of each condition),
+all sized to ``1920*1080`` pixels (the entirety of the screen).
+
+.. vimeo:: 856938009
+    :align: center
+    :width: 75%
+
+Conditions
+----------
+
+Naturalistic
+    Video of 3 actors jumping and moving with objects in their hands
+    (i.e. balloons)
+Scrambled
+    Pixelated copy of the Naturalistic videos
+
+Interest Areas
+--------------
+
+Calibration Animation
+    A central animation that is presented at the beginning of each trial. The trial
+    proceeds when gaze is held within the 200px diameter interest area surrounding the
+    animation for ``50ms``.
+Stimuli Interest Areas
+    There are three large interest areas (IA) corresponding with the location of each of
+    the actors on the screen, shown in Figure 9. They are labeled ``“Left_IA”``,
+    ``“Center_IA”``, and ``“Right_IA”`` in the Experiment builder file.
+
+Event Messaging
+---------------
+Each trial begins with the onset of the calibration dot, which writes the message
+``"CALIB_ANIMATION_ONSET"``, and when the invisible boundary trigger fires the message
+``"GAZE_TO_CALIB"`` is written. When the video plays the message ``"SYNC FRAME No. 1"``
+is written with the corresponding frame of the video as the numeric at the end. In
+theory this message could help with the production of dynamic interest areas
+(if required) as these could be matched to frame numbers. When the video is complete,
+the message ``"DISPLAY_BLANK"`` is written, corresponding with the display of the blank
+screen ending the trial.


### PR DESCRIPTION
Add documentation for the NSP task.

BTW  @gabe33033 @dsrishyla - Besides our own SOP documentation, I think the original [Jono Documentation](https://docs.google.com/document/d/1kzT9hxsTZ3FtkB484QUae4wMOQ5KEh_z/edit) actually provides a really nice template for the task documentation. you'll notice that what I've done for GO (and now NSP) closely follows Jono's documentation.

Please do not hesitate to reach out to me if you get stuck anywhere. 